### PR TITLE
Support initial data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
 # Merge-Queue
-
-
 ![Merge-Queue Minzipped Size](https://badgen.net/npm/v/merge-queue?icon=npm)
 ![Github Checks](https://badgen.net/github/checks/LorisSigrist/merge-queue?icon=github)
 
@@ -124,6 +122,24 @@ const [operation_2, data_2] = q.dequeue(); // ["operation_2", data_2]
 const [operation_3, data_3] = q.dequeue(); // ["operation_3", data_3]
 
 q.length; //0
+```
+
+
+### Loading and Saving the Queue
+```ts
+import { MergeQueue } from "merge-queue";
+
+const queue_1 = MergeQueue();
+
+queue_1.enqueue("operation_1", data_1);
+queue_1.enqueue("operation_2", data_2);
+
+
+//You can export the queue as an array
+console.log(queue_1.toArray()) // [ ["operation_1", data_1], ["operation_2", data_2] ]
+
+//You can initialize a new queue with the array
+const queue_2 = MergeQueue(queue_1.toArray());
 ```
 
 ### Operations that Cancel

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,10 @@ type Queue<OperationsMap> = {
     [OperationKey in keyof OperationsMap]: [OperationKey, OperationsMap[OperationKey]];
 }[Extract<keyof OperationsMap, string>][];
 
+type InitialQueue<OperationsMap> = {
+    [OperationKey in keyof OperationsMap]: [OperationKey, OperationsMap[OperationKey]];
+}[Extract<keyof OperationsMap, string>][];
+
 
 interface MergeQueueReturn<OperationsMap extends {} = any> {
     /** Adds an item to the queue */
@@ -59,7 +63,7 @@ interface MergeQueueReturn<OperationsMap extends {} = any> {
 }
 
 
-export function MergeQueue<OperationsMap extends {} = any>(): MergeQueueReturn<OperationsMap> {
+export function MergeQueue<OperationsMap extends {} = any>(initial_data: InitialQueue<OperationsMap> = []): MergeQueueReturn<OperationsMap> {
 
     /*
         TS can be a bit of a pain to work with sometimes.
@@ -76,7 +80,7 @@ export function MergeQueue<OperationsMap extends {} = any>(): MergeQueueReturn<O
      * The queue of operations. Stored oldest to newest.
      * New items are appended to the end
      */
-    let queue: Queue<OperationsMap> = [];
+    let queue: Queue<OperationsMap> = initial_data;
 
     type Merger = (a: any, b: any) => [string, any] | null;
 

--- a/tests/queue-with-initial-data.test.ts
+++ b/tests/queue-with-initial-data.test.ts
@@ -1,35 +1,51 @@
-import {describe, it, expect} from "vitest"
+import { describe, it, expect } from "vitest"
 import { MergeQueue } from "../src/"
 
 describe("Queue with inital Data", () => {
 
     it("should initialize a queue with data", () => {
         const queue = MergeQueue([
-        ["a", 1],
-        ["b", 2],
-        ["c", 3],
+            ["a", 1],
+            ["b", 2],
+            ["c", 3],
         ])
-    
+
         expect(queue.toArray()).toEqual([
-        ["a", 1],
-        ["b", 2],
-        ["c", 3],
-        ])
-    })
-    
-    it("should initialize with initial data and then apply merge rules", () => {
-        const queue = MergeQueue([
-        ["a", 1],
-        ["b", 2],
-        ["c", 3],
-        ])
-    
-        queue.addMergeRule("a", "b", (a, b) => ["c", a + b])
-    
-        expect(queue.toArray()).toEqual([
-        ["c", 3],
-        ["c", 3],
+            ["a", 1],
+            ["b", 2],
+            ["c", 3],
         ])
     })
 
+    it("should initialize with initial data and then apply merge rules", () => {
+        const queue = MergeQueue([
+            ["a", 1],
+            ["b", 2],
+            ["c", 3],
+        ])
+
+        queue.addMergeRule("a", "b", (a, b) => ["c", a + b])
+
+        expect(queue.toArray()).toEqual([
+            ["c", 3],
+            ["c", 3],
+        ])
+    })
+
+
+    it("should be able to be initialized from another queue", () => {
+        const queue = MergeQueue([
+            ["a", 1],
+            ["b", 2],
+            ["c", 3],
+        ])
+
+        const queue2 = MergeQueue(queue.toArray())
+
+        expect(queue2.toArray()).toEqual([
+            ["a", 1],
+            ["b", 2],
+            ["c", 3],
+        ])
+    });
 });

--- a/tests/queue-with-initial-data.test.ts
+++ b/tests/queue-with-initial-data.test.ts
@@ -1,0 +1,35 @@
+import {describe, it, expect} from "vitest"
+import { MergeQueue } from "../src/"
+
+describe("Queue with inital Data", () => {
+
+    it("should initialize a queue with data", () => {
+        const queue = MergeQueue([
+        ["a", 1],
+        ["b", 2],
+        ["c", 3],
+        ])
+    
+        expect(queue.toArray()).toEqual([
+        ["a", 1],
+        ["b", 2],
+        ["c", 3],
+        ])
+    })
+    
+    it("should initialize with initial data and then apply merge rules", () => {
+        const queue = MergeQueue([
+        ["a", 1],
+        ["b", 2],
+        ["c", 3],
+        ])
+    
+        queue.addMergeRule("a", "b", (a, b) => ["c", a + b])
+    
+        expect(queue.toArray()).toEqual([
+        ["c", 3],
+        ["c", 3],
+        ])
+    })
+
+});


### PR DESCRIPTION
Adds support for initialising Queues with some initial data.
That data can for example be provieded by exporting another queue using `q.toArray()`.